### PR TITLE
Update directory adjustments / same indentation for multi-line entries

### DIFF
--- a/misc/header.tex
+++ b/misc/header.tex
@@ -69,11 +69,17 @@
   % Other directories
   % Required directory adjustments
   \usepackage[subfigure]{tocloft}
-  \renewcommand{\cftfigfont}{Abbildung }
-  \renewcommand{\cfttabfont}{Tabelle }
+  \renewcommand{\cftfigpresnum}{Abbildung }
+  \renewcommand{\cfttabpresnum}{Tabelle }  
   \renewcommand{\cftfigaftersnum}{:}
   \renewcommand{\cfttabaftersnum}{:}
-  
+  \newlength{\ctmfignumwidth}
+  \newlength{\ctmtabnumwidth}
+  \settowidth{\ctmfignumwidth}{\cftfigpresnum}
+  \settowidth{\ctmtabnumwidth}{\cfttabpresnum}
+  \setlength{\cftfignumwidth}{\dimexpr\ctmfignumwidth+1.5em}
+  \setlength{\cfttabnumwidth}{\dimexpr\ctmtabnumwidth+1.5em}
+
   %**************************************************************
   % Graphics
   %

--- a/misc/header.tex
+++ b/misc/header.tex
@@ -79,6 +79,10 @@
   \settowidth{\ctmtabnumwidth}{\cfttabpresnum}
   \setlength{\cftfignumwidth}{\dimexpr\ctmfignumwidth+1.5em}
   \setlength{\cfttabnumwidth}{\dimexpr\ctmtabnumwidth+1.5em}
+  % remove indentation from figures in lof
+  \setlength{\cftfigindent}{0pt}
+  % remove indentation from tables in lot
+  \setlength{\cfttabindent}{0pt}
 
   %**************************************************************
   % Graphics


### PR DESCRIPTION
**Changes**:
- same indentation for multi-line entries
- remove indentation from figures and tables 


**Before**:
![before](https://user-images.githubusercontent.com/13857929/60754294-820e2800-9fdf-11e9-8355-d155fd2ce334.PNG)

**After**:
![after](https://user-images.githubusercontent.com/13857929/60754658-9dc7fd00-9fe4-11e9-883a-6511539eea0d.PNG)

Reference: Roter Grubert Page 61 / 62