### PR TITLE
Fix independence notice \dotfill bug

### DIFF
--- a/template/independence-notice.tex
+++ b/template/independence-notice.tex
@@ -1,18 +1,21 @@
 %!TEX root = ../root.tex
 
 \newpage
-\section*{Selbstständigkeitserklärung}
-\addcontentsline{toc}{section}{Selbstständigkeitserklärung}
-Ich versichere hiermit, dass ich meine \mytexttype \ mit dem Thema
+
+\section*{Selbstständigkeitserklärung}\addcontentsline{toc}{section}{Selbstständigkeitserklärung}
+Ich versichere hiermit, dass ich meine \mytexttype{} mit dem Thema
+
 \begin{center}
-\textbf{{\large \mytitle} \\ \mysubtitle}
+    \textbf{{\large \mytitle{}} \\\mysubtitle{}}
 \end{center}
-selbstständig und nur mit den angegebenen Quellen und Hilfsmitteln verfasst habe sowie dass die eingereichte gedruckte Version mit der elektronischen Version inhaltlich übereinstimmt.\\
-\\
-\vspace{15mm}
-\noindent{}\mysubmissionplace , \mydate
+
+selbstständig und nur mit den angegebenen Quellen und Hilfsmitteln verfasst habe sowie dass die eingereichte gedruckte Version mit der elektronischen Version inhaltlich übereinstimmt.
+
+\vspace{1cm}
+\mysubmissionplace{},\ \mydate{}
 \hfill
-\begin{minipage}[t]{6cm}
-\centering \dotfill \\
-\myauthor
+\begin{minipage}[t]{5.5cm}
+    \centering
+    \dotfill \\
+    \myauthor{}
 \end{minipage}


### PR DESCRIPTION
The \dotfill line was too long for "Villingen-Schwenningen" and a full date being in the same line.

Also improved formatting 😄 