### PR TITLE
fix: install udhbwvst in TEXMFLOCAL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM danteev/texlive:latest
 
 ADD ./src/ /tmp/src
-RUN mkdir -p $(kpsewhich -var-value TEXMFHOME)/tex/latex/udhbwvst \
-    && mv /tmp/src/udhbwvst* $(kpsewhich -var-value TEXMFHOME)/tex/latex/udhbwvst/ \
-    && texhash $(kpsewhich -var-value TEXMFHOME) \
+RUN mkdir -p $(kpsewhich -var-value TEXMFLOCAL)/tex/latex/udhbwvst \
+    && mv /tmp/src/udhbwvst* $(kpsewhich -var-value TEXMFLOCAL)/tex/latex/udhbwvst/ \
+    && texhash $(kpsewhich -var-value TEXMFLOCAL) \
     && rm -rf /tmp/src
 
 RUN mkdir /work


### PR DESCRIPTION
This way all users can access the `udhbwvst` class in the container, not only root! This enables using the `skyfrk/udhbwvst` docker container in CI systems like GitHub Actions :)

Edit: In GitHub Actions for example you previously had to run `ln -s /root/texmf /github/home/` before building your pdf file...


