### PR TITLE
feat: improve url linebreaks by loading xurl

### DIFF
--- a/src/udhbwvst.cls
+++ b/src/udhbwvst.cls
@@ -131,6 +131,8 @@
 \RequirePackage[title,titletoc]{appendix}
 \RequirePackage{rotating}
 \RequirePackage[absolute]{textpos}
+\RequirePackage{xurl} % for better url linebreaks
+
 
 % load optional packages
 


### PR DESCRIPTION
xurl docs: https://ctan.org/tex-archive/macros/latex/contrib/xurl

before:
![image](https://user-images.githubusercontent.com/27026029/82335787-1744c000-99ea-11ea-9ddb-6c794cd571ba.png)

after:
![image](https://user-images.githubusercontent.com/27026029/82336058-668af080-99ea-11ea-8249-8ffc251104c2.png)


