### PR TITLE
fix: force hyperref to use unicode pdf encoding

### DIFF
--- a/src/udhbwvst.cls
+++ b/src/udhbwvst.cls
@@ -78,7 +78,7 @@
       pdfauthor   = {\ifdef{\dhbwGetAuthor}{\dhbwGetAuthor}{undefined}},
       pdfcreator  = {Lua\LaTeX},
       pdfproducer = {Lua\LaTeX},
-      pdfencoding = {auto},
+      pdfencoding = {unicode},
       pdflang     = {de}
     }
 }


### PR DESCRIPTION
closes #100
