### PR TITLE
fix: use better words in \autoref{}

### DIFF
--- a/examples/full/full.tex
+++ b/examples/full/full.tex
@@ -228,6 +228,32 @@ Gem.\ §2 Abs.\ 3 S.\ 3 BGB kann man auch Gesetze zitieren btw.\nocite{bgb}
 
 Man kann auch Urteile zitieren.\ifootcite{shell}
 
+\section{This is a section}\label{sec:section}
+
+\lipsum
+
+\subsection{This is a subsection}\label{sec:subsection}
+
+\lipsum
+
+\subsubsection{This is a subsubsection}\label{sec:subsubsection}
+
+\lipsum
+
+\paragraph{This is a paragraph}\label{sec:paragraph}
+
+\lipsum
+
+\section{lets refer}
+
+section: \autoref{sec:section}
+
+subsection: \autoref{sec:subsection}
+
+subsubsection: \autoref{sec:subsubsection}
+
+paragraph: \autoref{sec:paragraph}
+
 \begin{dhbwappendices}
 
     \dhbwAppendix{test}

--- a/src/udhbwvst.cls
+++ b/src/udhbwvst.cls
@@ -82,6 +82,12 @@
       pdfencoding = {unicode},
       pdflang     = {de}
     }
+    \addto\extrasngerman{%
+      \renewcommand{\sectionautorefname}{Kapitel}%
+      \renewcommand{\subsectionautorefname}{Unterkapitel}%
+      \renewcommand{\subsubsectionautorefname}{Unterkapitel}%
+      \renewcommand{\paragraphautorefname}{Unterkapitel}%
+    }
 }
 
 \RequirePackage{fontspec}


### PR DESCRIPTION
## use better words in \autoref{}

Paragraph was using `Absatz` before 😕.

- `Kapitel` for sections.
- `Unterkapitel` for subsections, subsubsections and paragraphs.