### PR TITLE
feat: add twoside support

### DIFF
--- a/src/udhbwvst.cls
+++ b/src/udhbwvst.cls
@@ -48,12 +48,14 @@
     title-style/default/.estyle = {/udhbwvst/title-style-file = udhbwvst-title-default.def},
     font-size/.store in         = \udhbwvst@var@fontsize,
     font-size                   = 12pt,
-    abstract-file/.store in     = \udhbwvst@var@abstractfile
+    abstract-file/.store in     = \udhbwvst@var@abstractfile,
+    layout/.store in            = \udhbwvst@var@layout,
+    layout                      = oneside
 }
 
 \ProcessPgfOptions{/udhbwvst}
 
-\LoadClass[\udhbwvst@var@fontsize]{article}
+\LoadClass[\udhbwvst@var@fontsize,\udhbwvst@var@layout]{article}
 
 % load packages
 


### PR DESCRIPTION
It would be nice to support the `twoside` layout for amazing print versions of our theses. I'm not sure however if I have enough time to figure this out until deadline 😁.

## TODOs

- [ ] Fix page number position
- [ ] Add a way to separate the title page (as cover), as it is [advised to do so](https://tex.stackexchange.com/a/57176/166545).